### PR TITLE
Change qemu to host dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,16 @@
 {
   description = "A flake to set up a development shell with the RISC-V 64 GNU toolchain";
-
   inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-
   outputs = { nixpkgs, ... }:
     let
       system = "x86_64-linux";
+      # Host (x86_64) pkgs — for tools we run on the build machine
+      # (e.g. the qemu user-mode emulator).
+      pkgsHost = import nixpkgs { inherit system; };
+      # Cross pkgs — for the RISC-V toolchain (gcc, binutils, glibc)
+      # and anything the test binary links against.
       pkgs = import nixpkgs {
-          system = "x86_64-linux";
+          inherit system;
           crossSystem = {
             config = "riscv64-unknown-linux-gnu";
           };
@@ -18,11 +21,9 @@
       devShells.${system}.default = stdenv.mkDerivation
         {
           name = "RISC-V 64 Toolchain";
-
           nativeBuildInputs = [
-            qemu
+            pkgsHost.qemu
           ];
-
           buildInputs = [
             glibc.static
           ];


### PR DESCRIPTION
Qemu has been declared as a dependency for the cross compiled target before. Usually, we want to run qemu on the x86 host machine. This has been fixed in this PR